### PR TITLE
fix(generator): correct PURL encoding for model IDs

### DIFF
--- a/HF_files/aibom-generator/src/aibom-generator/generator.py
+++ b/HF_files/aibom-generator/src/aibom-generator/generator.py
@@ -239,15 +239,15 @@ class AIBOMGenerator:
                 }
             },
             "components": [{
-                "bom-ref": f"pkg:huggingface/{model_id.replace('/', '/')}@1.0",
+                "bom-ref": f"pkg:huggingface/{model_id.replace('/', '%2F')}@1.0",
                 "type": "machine-learning-model",
                 "name": model_id.split("/")[-1],
                 "version": "1.0",
-                "purl": f"pkg:huggingface/{model_id.replace('/', '/')}@1.0"
+                "purl": f"pkg:huggingface/{model_id.replace('/', '%2F')}@1.0"
             }],
             "dependencies": [{
                 "ref": f"pkg:generic/{model_id.replace('/', '%2F')}@1.0",
-                "dependsOn": [f"pkg:huggingface/{model_id.replace('/', '/')}@1.0"]
+                "dependsOn": [f"pkg:huggingface/{model_id.replace('/', '%2F')}@1.0"]
             }]
         }
 
@@ -318,7 +318,7 @@ class AIBOMGenerator:
             "dependencies": [
                 {
                     "ref": f"pkg:generic/{model_id.replace('/', '%2F')}@{version}",
-                    "dependsOn": [f"pkg:huggingface/{model_id.replace('/', '/')}@{version}"]
+                    "dependsOn": [f"pkg:huggingface/{model_id.replace('/', '%2F')}@{version}"]
                 }
             ]
         }
@@ -585,14 +585,14 @@ class AIBOMGenerator:
         version = metadata.get("commit", "1.0")
         
         # Create PURL with version information if commit is available
-        purl = f"pkg:huggingface/{model_id.replace('/', '/')}"
+        purl = f"pkg:huggingface/{model_id.replace('/', '%2F')}"
         if "commit" in metadata:
             purl = f"{purl}@{metadata['commit']}"
         else:
             purl = f"{purl}@{version}"
             
         component = {
-            "bom-ref": f"pkg:huggingface/{model_id.replace('/', '/')}@{version}",
+            "bom-ref": f"pkg:huggingface/{model_id.replace('/', '%2F')}@{version}",
             "type": "machine-learning-model",
             "group": group,
             "name": name,


### PR DESCRIPTION
## Summary
- Fix no-op `.replace('/', '/')` calls that were intended to URL-encode forward slashes in model IDs
- Replace with `.replace('/', '%2F')` to properly encode per the PURL specification

## Problem
The code had 6 instances of `.replace('/', '/')` which does nothing (replaces `/` with `/`). This resulted in invalid PURLs like:
```
pkg:huggingface/meta-llama/Llama-3.1-8B@1.0
```

## Solution
Changed to `.replace('/', '%2F')` to produce valid PURLs:
```
pkg:huggingface/meta-llama%2FLlama-3.1-8B@1.0
```

## Test plan
- [x] Built Docker image with fix
- [x] Tested with `meta-llama/Llama-3.1-8B` model
- [x] Verified `bom-ref` and `purl` fields contain `%2F` encoding
- [x] Confirmed no remaining instances of the bug pattern

Fixes #13