### PR TITLE
feat: adding logic to enable use with earlier supported python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 .env
 venv/
 .venv/
+.venv-*/
 env/
 dist/
 build/

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,17 @@
-import os
+from __future__ import annotations
+
+import os, sys
 from pathlib import Path
-import tomllib
+
+sys.version_info >= (3, 8) or sys.exit("Python 3.8 or higher is required for this project.")
+
+if sys.version_info < (3, 11):
+    import tomli as tomllib
+else:
+    import tomllib
+
+
+
 
 
 # Base Directory Setup


### PR DESCRIPTION
Resolves #71 

### Summary
- Import `__future__.annotations` to allow type hinting across all supported versions
- Added `sys.version_info` check to ensure Python version being used is supported by the tool.
- Added sys.version_info check to import `tomllib` only if Python version is compatible. Otherwise imports `tomli` as `tomllib` to ensure functionality in earlier supported Python versions.
- Added line to .gitignore to ignore versioned .venv directories.

### Changes
| File                    | Purpose                                                                                                                      |
| ----------------- | ----------------------------------------------------------------------------------------- |
| /src/config.py    | Import __future__.annotations, tomllib => tomli downgrade logic to enable earlier supported versions |  
| .gitignore           | Ignore versioned .venv files (ex. .venv-3.8, .venv-3.11.7) |