### PR TITLE
feat(dev): add pre-commit hooks for code quality and security

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+      - id: check-merge-conflict
+      - id: debug-statements
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.3
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ dev = [
     "pytest-cov>=4.0.0",
     "pytest-mock>=3.10.0",
     "ruff",
-    "gguf>=0.6.0"
+    "gguf>=0.6.0",
+    "pre-commit>=3.0.0",
+    "bandit[toml]>=1.7.0"
 ]
 
 [project.scripts]
@@ -68,6 +70,31 @@ testpaths = [
 pythonpath = [
     "."
 ]
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "UP",   # pyupgrade
+]
+ignore = [
+    "E501",  # line too long (handled by formatter)
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["src"]
+
+[tool.bandit]
+exclude_dirs = ["tests"]
+skips = ["B101"]  # allow assert in tests
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` with hooks for trailing whitespace, EOF fixer, YAML validation, large file detection (500KB), merge conflict markers, and debug statement detection
- Add **ruff** pre-commit hooks for linting (with auto-fix) and code formatting
- Add **bandit** pre-commit hook for automated security scanning
- Add `[tool.ruff]` and `[tool.bandit]` configuration to `pyproject.toml`
- Add `pre-commit` and `bandit[toml]` to dev dependencies

## Ruff rules enabled

| Rule | Description |
|------|-------------|
| `E` | pycodestyle errors |
| `W` | pycodestyle warnings |
| `F` | pyflakes |
| `I` | isort (import sorting) |
| `B` | flake8-bugbear |
| `UP` | pyupgrade |

## Setup for contributors

```bash
pip install -e ".[dev]"
pre-commit install
```

## Test plan

- [x] `pre-commit` and `bandit` install successfully via `pip install -e ".[dev]"`
- [ ] `pre-commit run --all-files` passes on the codebase
- [ ] `pre-commit install` sets up git hooks correctly
- [ ] Committing a file with trailing whitespace triggers the hook

Closes #51

Generated with [Claude Code](https://claude.com/claude-code)