### PR TITLE
fix(scoring): detect externalReferences under components[0] (#76)

### DIFF
--- a/src/models/field_registry.json
+++ b/src/models/field_registry.json
@@ -512,7 +512,7 @@
       "weight": 1.0,
       "category": "component_basic",
       "description": "Additional external references",
-      "jsonpath": "$.component.externalReferences",
+      "jsonpath": "$.components[0].externalReferences",
       "aibom_generation": {
         "location": "$.component.externalReferences",
         "rule": "include_if_available",

--- a/src/models/scoring.py
+++ b/src/models/scoring.py
@@ -70,6 +70,15 @@ def validate_spdx(license_entry):
         return all(lic in SPDX_LICENSES for lic in license_entry)
     return license_entry in SPDX_LICENSES
 
+# CycloneDX component keys are camelCase, while some registry field names are
+# snake_case. Map the registry name to the BOM key so the fallback presence check
+# does not score a populated field as missing (see #76).
+_COMPONENT_KEY_ALIASES = {
+    "external_references": "externalReferences",
+    "component_version": "version",
+}
+
+
 def check_field_in_aibom(aibom: Dict[str, Any], field: str) -> bool:
     """
     Check if a field is present in the AIBOM (Legacy/Standard Layout check).
@@ -94,7 +103,7 @@ def check_field_in_aibom(aibom: Dict[str, Any], field: str) -> bool:
     components = aibom.get("components", [])
     if components:
         component = components[0]
-        if field in component:
+        if field in component or _COMPONENT_KEY_ALIASES.get(field) in component:
             return True
         
         # Component Properties

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,5 +1,10 @@
 import unittest
-from src.models.scoring import calculate_completeness_score, ValidationSeverity
+from src.models.scoring import (
+    calculate_completeness_score,
+    check_field_in_aibom,
+    check_field_with_enhanced_results,
+    ValidationSeverity,
+)
 
 class TestScoring(unittest.TestCase):
     def test_basic_completeness(self):
@@ -37,6 +42,38 @@ class TestScoring(unittest.TestCase):
         aibom = {}
         score = calculate_completeness_score(aibom)
         self.assertIsNotNone(score)
+
+    def test_external_references_detected_under_components_array(self):
+        # Regression for #76: externalReferences lives under components[0]
+        # (plural, camelCase) in CycloneDX 1.6/1.7, so a populated field must be
+        # detected as present rather than scored as missing.
+        aibom = {
+            "bomFormat": "CycloneDX",
+            "components": [
+                {
+                    "name": "test-model",
+                    "type": "machine-learning-model",
+                    "externalReferences": [
+                        {"type": "website", "url": "https://example.com"},
+                        {"type": "vcs", "url": "https://github.com/example/model"},
+                    ],
+                }
+            ],
+        }
+        # registry jsonpath detection ($.components[0].externalReferences)
+        self.assertTrue(check_field_with_enhanced_results(aibom, "external_references"))
+        # fallback presence check resolves the snake_case -> camelCase alias
+        self.assertTrue(check_field_in_aibom(aibom, "external_references"))
+
+    def test_external_references_absent_is_not_reported_present(self):
+        # Negative guard: with no externalReferences, detection stays False so
+        # the fix cannot regress into always-present.
+        aibom = {
+            "bomFormat": "CycloneDX",
+            "components": [{"name": "m", "type": "machine-learning-model"}],
+        }
+        self.assertFalse(check_field_with_enhanced_results(aibom, "external_references"))
+        self.assertFalse(check_field_in_aibom(aibom, "external_references"))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What

`external_references` always scored as missing in the `component_basic` category, even when the generated BOM contained a populated `externalReferences` array, capping every model at ~17.1/20 there. Fixes #76.

## Root cause

Two independent detection issues:

1. `field_registry.json` used the singular jsonpath `$.component.externalReferences`, but CycloneDX 1.6/1.7 place the array under `$.components[0]` (plural with index). Every other `component_basic` field already uses `$.components[0].*`.
2. The fallback presence check in `scoring.py` compared the snake_case registry name `external_references` against the camelCase BOM key `externalReferences`, so neither path matched a populated field.

## Change

- `field_registry.json`: jsonpath -> `$.components[0].externalReferences` (scoring/detection path only).
- `scoring.py`: a small registry-name -> BOM-key alias map used by the fallback check, as defense-in-depth (also covers `component_version` -> `version`).
- `tests/test_scoring.py`: a positive case (detection under `components[0]` via both the jsonpath and the fallback) and a negative guard (absent -> still False).

With both, a fully populated `component_basic` scores 20/20 again.

## Scope

I left the `aibom_generation.location` strings untouched. They use a separate singular-`$.component.` addressing scheme consistently across the registry (the component being generated, not the final BOM array), and generated BOMs already place `externalReferences` correctly under `components[0]`, so this PR stays limited to the scoring/detection bug. Happy to revisit the generation convention separately if maintainers prefer.

Credit to the reporter for the precise root-cause analysis.
